### PR TITLE
Update terminology and rename `to_subcatalog` methods

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -31,7 +31,7 @@ about:
   home: https://github.com/ACCESS-NRI/intake-dataframe-catalog
   license: Apache Software
   license_family: APACHE
-  summary: "An intake driver for a searchable table of intake catalogs and associated metadata"
+  summary: "An intake driver for a searchable table of intake sources and associated metadata"
   doc_url: https://intake-dataframe-catalog.readthedocs.io/en/latest/?badge=latest
 
 extra:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,14 @@ Changelog
 0.1.1
 -----
 
-Not yet released
+Released 12/05/2023
 
-- update descriptions of this package to be more correct (:issue:`27`, :pull:`28`).
+- Rename methods :code:`to_subcatalog` and :code:`to_subcatalog_dict` to :code:`to_source` and 
+  :code:`to_source_dict` respectively and add depreciation warnings (:issue:`27`, :pull:`28`).
   By `Dougie Squire <https://github.com/dougiesquire>`_.
-- use :code:`load_setup_py_data` from :code:`conda-build` to template version in meta.yaml.
+- Update terminology to better align with intake (:issue:`27`, :pull:`28`).
+  By `Dougie Squire <https://github.com/dougiesquire>`_.
+- Use :code:`load_setup_py_data` from :code:`conda-build` to template version in meta.yaml.
   By `Dougie Squire <https://github.com/dougiesquire>`_.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 
 Not yet released
 
+- update descriptions of this package to be more correct (:issue:`27`, :pull:`28`).
+  By `Dougie Squire <https://github.com/dougiesquire>`_.
 - use :code:`load_setup_py_data` from :code:`conda-build` to template version in meta.yaml.
   By `Dougie Squire <https://github.com/dougiesquire>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Why?
 Intake already provides the ability to 
 `nest sources in a catalog <https://intake.readthedocs.io/en/latest/catalog.html#catalog-nesting>`_ 
 and search across them. However, data discoverability is limited in the case of very large numbers
-of nested sources, and the search functionality does readily provide the ability to execute 
+of nested sources, and the search functionality does not readily provide the ability to execute 
 complex searches on nested source metadata. intake-dataframe-catalog aims to provide a very
 simple catalog of intake sources that emphasises source search and discoverability.
     

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 intake-dataframe-catalog
 ========================
 
-**A simple intake plugin for a searchable table of intake catalogs and associated metadata.**
+**A simple intake plugin for a searchable table of intake sources and associated metadata.**
 
 ------------
 
@@ -21,27 +21,26 @@ intake-dataframe-catalog
 Overview
 --------
 
-intake-dataframe-catalog is a simple intake plugin for a searchable table of intake catalogs. 
+intake-dataframe-catalog is a simple intake plugin for a searchable table of intake sources. 
 The table is represented in memory as a pandas DataFrame and can be serialized and shared as 
-a CSV file. Each row in the dataframe catalog corresponds to another intake catalog (refered 
-to in this documentation as a "subcatalog") and the columns contain metadata associated with 
-each subcatalog that a user may want to peruse and/or search. The original use-case for 
-intake-dataframe-catalog was to provide a user-friendly catalog of a large number 
-`intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_ catalogs. intake-dataframe-catalog 
-enables users to peruse and search on core metadata from each intake-esm subcatalog to find 
-the subcatalogs that are most relevant to their work (e.g. "which subcatalogs contain model 
-X and variable Y?"). Once a users has found the subcatalog(s) that interest them, they can 
-load those subcatalogs and access the data they reference.
+a CSV file. Each row in the dataframe catalog corresponds to an intake source and the columns 
+contain metadata associated with each source that a user may want to peruse and/or search. 
+The original use-case for intake-dataframe-catalog was to provide a user-friendly catalog of 
+a large number `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_ datastores. 
+intake-dataframe-catalog enables users to peruse and search on core metadata from each 
+intake-esm datastore to find the datastores that are most relevant to their work (e.g. 
+"which datastores contain model X and variable Y?"). Once a users has found the datastores(s) 
+that interest them, they can load those datastores and access the data they reference.
 
 Why?
 ----
 
 Intake already provides the ability to 
-`nest catalogs <https://intake.readthedocs.io/en/latest/catalog.html#catalog-nesting>`_ and 
-search across them. However, data discoverability is limited in the case of very large numbers
-of nested catalogs, and the search functionality does readily provide the ability to execute 
-complex searches on nested catalog metadata. intake-dataframe-catalog aims to provide a very
-simple catalog of subcatalogs that emphasises subcatalog search and discoverability.
+`nest sources in a catalog <https://intake.readthedocs.io/en/latest/catalog.html#catalog-nesting>`_ 
+and search across them. However, data discoverability is limited in the case of very large numbers
+of nested sources, and the search functionality does readily provide the ability to execute 
+complex searches on nested source metadata. intake-dataframe-catalog aims to provide a very
+simple catalog of intake sources that emphasises source search and discoverability.
     
 
 .. |docs| image:: https://readthedocs.org/projects/intake-dataframe-catalog/badge/?version=latest

--- a/docs/getting_started/quickstart.ipynb
+++ b/docs/getting_started/quickstart.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "This page demonstrates how to use intake-dataframe-catalog by building and using a very simple dataframe catalog comprising a small number of publically-available intake-esm catalogs for the:\n",
+    "This page demonstrates how to use intake-dataframe-catalog by building and using a very simple dataframe catalog comprising a small number of publically-available intake-esm datastores for the:\n",
     "\n",
     "- [Community Earth System Model Large Ensemble (CESM LENS)](https://registry.opendata.aws/ncar-cesm-lens) data hosted on AWS by NCAR\n",
     "- [Coupled Model Intercomparison Project 6](https://registry.opendata.aws/cmip6/) data hosted on AWS by Pangeo\n",
@@ -37,7 +37,7 @@
    "id": "7f4ad5a7-9e1d-4ad6-a0ed-19a7b9567088",
    "metadata": {},
    "source": [
-    "First, we open each of the intake-esm catalogs. Our goal is to create an intake dataframe catalog with these as subcatalogs."
+    "First, we open each of the intake-esm datastores. Our goal is to create an intake dataframe catalog with these as the cataloged intake sources."
    ]
   },
   {
@@ -81,7 +81,7 @@
    "id": "7f2110f3-2ea1-45fe-ad09-d22438afbcaa",
    "metadata": {},
    "source": [
-    "Each of these intake-esm catalogs includes a table of remote zarr files and metadata associated with each file: "
+    "Each of these intake-esm datastores includes a table of remote zarr files and metadata associated with each file: "
    ]
   },
   {
@@ -358,7 +358,7 @@
    "id": "7c730533-0e5a-4e0d-9d8b-6cf77c91e63e",
    "metadata": {},
    "source": [
-    "While the metadata in each of our intake-esm catalogs may follow a different schema (e.g. the CMIP6 catalogs follow [cmip6 controlled vocabulary](https://pyessv.es-doc.org/1/retrieve/wcrp/cmip6)), all catalogs generally include the same sort of metadata. For example, all catalogs include metadata describing the models used, variables available, temporal frequency etc. These are the metadata we'll include in our intake dataframe catalog."
+    "While the metadata in each of our intake-esm datastores may follow a different schema (e.g. the CMIP6 datastores follow [cmip6 controlled vocabulary](https://pyessv.es-doc.org/1/retrieve/wcrp/cmip6)), all datastores generally include the same sort of metadata. For example, all datastores include metadata describing the models used, variables available, temporal frequency etc. These are the metadata we'll include in our intake dataframe catalog."
    ]
   },
   {
@@ -392,7 +392,7 @@
    "id": "de370400-526e-424b-a68b-f9297873fbb2",
    "metadata": {},
    "source": [
-    "## Adding subcatalogs"
+    "## Adding sources"
    ]
   },
   {
@@ -400,7 +400,7 @@
    "id": "c94f4877-c3e2-4084-b9ee-70bf4a420641",
    "metadata": {},
    "source": [
-    "We can add subcatalogs to the dataframe catalog using the `.add` method. This method takes as arguments the subcatalog to add and the metadata to associate with that subcatalog. As a simple demonstration, we'll add metadata about the model(s) and variable(s). We'll parse this metadata from each intake-esm catalog. The `aws_cesm2_lens` subcatalog comprises only one model and is the simplest to add:"
+    "We can add sources to the dataframe catalog using the `.add` method. This method takes as arguments the sources to add and the metadata to associate with that source. As a simple demonstration, we'll add metadata about the model(s) and variable(s). We'll parse this metadata from each intake-esm datastores. The `aws_cesm2_lens` datastores comprises only one model and is the simplest to add:"
    ]
   },
   {
@@ -483,7 +483,7 @@
    "id": "1d4333bb-0d48-4c17-90e5-a5ff9f5bffce",
    "metadata": {},
    "source": [
-    "Both the CMIP6 catalogs comprise multiple models. In order to keep track of which variables are available for which models we must add an entry in our dataframe catalog for each model. To do this, we'll write a simple function for finding which variables are available for a given model:"
+    "Both the CMIP6 datastores comprise multiple models. In order to keep track of which variables are available for which models we must add an entry in our dataframe catalog for each model. To do this, we'll write a simple function for finding which variables are available for a given model:"
    ]
   },
   {
@@ -495,7 +495,7 @@
    "source": [
     "def get_variables_for_model(subcat, model):\n",
     "    \"\"\"\n",
-    "    Returns a list of unique variables for a given model in a CMIP6 intake-esm catalog\n",
+    "    Returns a list of unique variables for a given model in a CMIP6 intake-esm datastore\n",
     "    \"\"\"\n",
     "    return list(\n",
     "        set(\n",
@@ -509,7 +509,7 @@
    "id": "a4187ef6-06b4-4462-9e9d-348f9b8f7c1b",
    "metadata": {},
    "source": [
-    "Then we can add the `aws_cmip6` subcatalog to our dataframe catalog:"
+    "Then we can add the `aws_cmip6` datastore to our dataframe catalog:"
    ]
   },
   {
@@ -534,7 +534,7 @@
    "id": "a5329f7a-f0e9-4c79-9f67-2b7c5edb2ba1",
    "metadata": {},
    "source": [
-    "And the same for the `google_cmip6` catalog:"
+    "And the same for the `google_cmip6` datastore:"
    ]
   },
   {
@@ -559,7 +559,7 @@
    "id": "f075dd95-81c3-4111-9d46-0e435f510ec4",
    "metadata": {},
    "source": [
-    "Note that even though we added separate rows for each model in each CMIP6 catalog, we still see a convenient summary with only one row per subcatalog when we display the dataframe in a Jupyter environment (note, this is displaying the `.df_summary` property of `cat`):"
+    "Note that even though we added separate rows for each model in each CMIP6 datastore, we still see a convenient summary with only one row per source when we display the dataframe in a Jupyter environment (note, this is displaying the `.df_summary` property of `cat`):"
    ]
   },
   {
@@ -639,7 +639,7 @@
    "id": "f94e6eda-60d1-40a8-87a9-a96ae18bb9bb",
    "metadata": {},
    "source": [
-    "Passing `overwrite=True` to `.add` will overwrite any existing subcatalog entries with the same name:"
+    "Passing `overwrite=True` to `.add` will overwrite any existing source entries with the same name:"
    ]
   },
   {
@@ -736,7 +736,7 @@
    "id": "4bd57c50-10be-47c9-a2a4-07e2f13ccfc3",
    "metadata": {},
    "source": [
-    "Once we're happy with the subcatalogs we have in our dataframe catalog, we can save it using the `.save` method:"
+    "Once we're happy with the sources we have in our dataframe catalog, we can save it using the `.save` method:"
    ]
   },
   {
@@ -785,7 +785,7 @@
    "id": "25cd3495-93e2-491c-9351-f357904dec1d",
    "metadata": {},
    "source": [
-    "We can use the `.search` method to find subcatalogs that satisfy metadata queries:"
+    "We can use the `.search` method to find sources that satisfy metadata queries:"
    ]
   },
   {
@@ -939,7 +939,7 @@
    "id": "6f2c3319-a723-4dca-abe2-60fca0821d3c",
    "metadata": {},
    "source": [
-    "By default, querying on a list as above returns subcatalogs that match on any of the values in the list. The `.search` method also has an optional `require_all` argument. If this is set to `True`, returned subcatalogs satisfy all the query criteria:"
+    "By default, querying on a list as above returns sources that match on any of the values in the list. The `.search` method also has an optional `require_all` argument. If this is set to `True`, returned sources satisfy all the query criteria:"
    ]
   },
   {
@@ -1011,7 +1011,7 @@
    "id": "6d383180-05f1-4fee-87a6-1c480f5ef9df",
    "metadata": {},
    "source": [
-    "Regex expressions can also be used in queries. For example, below we search for subcatalogs with variables containing word \"Fire\". We can see that only one model (GFDL-ESM4) in each of the CMIP6 catalogs contains variables matching this criteria:"
+    "Regex expressions can also be used in queries. For example, below we search for sources with variables containing word \"Fire\". We can see that only one model (GFDL-ESM4) in each of the CMIP6 datastores contains variables matching this criteria:"
    ]
   },
   {
@@ -1088,7 +1088,7 @@
    "id": "29b72809-7c00-41b1-8296-c133a8326daa",
    "metadata": {},
    "source": [
-    "## Loading subcatalogs"
+    "## Loading sources"
    ]
   },
   {
@@ -1096,7 +1096,7 @@
    "id": "839e2d38-da7b-43ae-9040-ba7f85fa2f86",
    "metadata": {},
    "source": [
-    "There are a few options for loading subcatalogs. We can load individual catalogs if we know their name:"
+    "There are a few options for loading sources. We can load individual sources if we know their name:"
    ]
   },
   {
@@ -1184,7 +1184,7 @@
     }
    ],
    "source": [
-    "cat[\"aws_cesm2_lens\"] # This is the aws_cesm2_lens intake-esm catalog"
+    "cat[\"aws_cesm2_lens\"] # This is the aws_cesm2_lens intake-esm datastore"
    ]
   },
   {
@@ -1192,7 +1192,7 @@
    "id": "3c0ffb21-3b49-46ee-9931-a188bf9a8da3",
    "metadata": {},
    "source": [
-    "Or (if the subcatalog name comprises only letters, numbers and underscores):"
+    "Or (if the source name comprises only letters, numbers and underscores):"
    ]
   },
   {
@@ -1288,7 +1288,7 @@
    "id": "668d133b-e8fb-41ca-80cf-db49627d4c43",
    "metadata": {},
    "source": [
-    "Alternatively, there are `.to_subcatalog` and `.to_subcatalog_dict` methods. The former only works when there is only one subcatalog remaining in the dataframe catalog (e.g. after performing `.search` operations). The latter loads all subcatalogs into a dictionary with the corresponding subcatalog names as keys:"
+    "Alternatively, there are `.get_source` and `.get_sources_dict` methods. The former only works when there is only one source remaining in the dataframe catalog (e.g. after performing `.search` operations). The latter loads all sources into a dictionary with the corresponding source names as keys:"
    ]
   },
   {
@@ -1376,7 +1376,7 @@
     }
    ],
    "source": [
-    "subcat = cat.search(variable=\"TEMP\").to_subcatalog()\n",
+    "subcat = cat.search(variable=\"TEMP\").get_source()\n",
     "\n",
     "subcat"
    ]
@@ -1401,7 +1401,7 @@
     }
    ],
    "source": [
-    "subcat_dict = cat.to_subcatalog_dict()\n",
+    "subcat_dict = cat.get_source_dict()\n",
     "\n",
     "subcat_dict"
    ]
@@ -1411,7 +1411,7 @@
    "id": "ab8024ab-e02d-4c6c-aea6-5eaefa5750c8",
    "metadata": {},
    "source": [
-    "Once subcatalogs are loaded, we can access data in the normal way for that intake source type. For example, see the [intake-esm documentation](https://intake-esm.readthedocs.io/en/latest/index.html) for how to use intake-esm catalogs like the ones we've using in this demonstration."
+    "Once sources are loaded, we can access data in the normal way for that intake source type. For example, see the [intake-esm documentation](https://intake-esm.readthedocs.io/en/latest/index.html) for how to use intake-esm catalogs like the ones we've using in this demonstration."
    ]
   }
  ],

--- a/docs/getting_started/quickstart.ipynb
+++ b/docs/getting_started/quickstart.ipynb
@@ -416,7 +416,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 1 subcatalog(s) across 1 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 1 source(s) across 1 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -447,7 +447,7 @@
        "    <tr>\n",
        "      <th>aws_cesm2_lens</th>\n",
        "      <td>{CESM2-LENS}</td>\n",
-       "      <td>{DIC, U, aice_d, NPP, QRUNOFF, hi, SALT, FSNTOA, TREFMXAV, RAIN, Q, TREFHT, WTT, PS, Z3, FLNSC, FLNS, PRECSC, O2, DOC, VVEL, PRECC, FSNO, PSL, nan, TREFHTMX, SHFLX, SOILLIQ, FLUT, PRECSL, T, VNT, ...</td>\n",
+       "      <td>{SOILWATER_10CM, TMQ, O2, V, WVEL, SNOW, DIC, Q, FLNS, FLNSC, hi, UVEL, T, Z3, RAIN, H2OSNO, ICEFRAC, PSL, PRECSL, NPP, nan, QRUNOFF, TREFHTMN, U, SALT, TEMP, FLUT, WTS, LHFLX, FSNSC, TREFHT, aice...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -493,13 +493,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_variables_for_model(subcat, model):\n",
+    "def get_variables_for_model(datastore, model):\n",
     "    \"\"\"\n",
     "    Returns a list of unique variables for a given model in a CMIP6 intake-esm datastore\n",
     "    \"\"\"\n",
     "    return list(\n",
     "        set(\n",
-    "            subcat.df[subcat.df.source_id == model].variable_id.unique().astype(str)\n",
+    "            datastore.df[datastore.df.source_id == model].variable_id.unique().astype(str)\n",
     "        )\n",
     "    )"
    ]
@@ -575,7 +575,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 3 subcatalog(s) across 177 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 3 source(s) across 177 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -606,17 +606,17 @@
        "    <tr>\n",
        "      <th>aws_cesm2_lens</th>\n",
        "      <td>{CESM2-LENS}</td>\n",
-       "      <td>{DIC, U, aice_d, NPP, QRUNOFF, hi, SALT, FSNTOA, TREFMXAV, RAIN, Q, TREFHT, WTT, PS, Z3, FLNSC, FLNS, PRECSC, O2, DOC, VVEL, PRECC, FSNO, PSL, nan, TREFHTMX, SHFLX, SOILLIQ, FLUT, PRECSL, T, VNT, ...</td>\n",
+       "      <td>{SOILWATER_10CM, TMQ, O2, V, WVEL, SNOW, DIC, Q, FLNS, FLNSC, hi, UVEL, T, Z3, RAIN, H2OSNO, ICEFRAC, PSL, PRECSL, NPP, nan, QRUNOFF, TREFHTMN, U, SALT, TEMP, FLUT, WTS, LHFLX, FSNSC, TREFHT, aice...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>aws_cmip6</th>\n",
-       "      <td>{MRI-AGCM3-2-H, CIESM, CanESM5, FGOALS-f3-L, HadGEM3-GC31-MM, INM-CM5-0, GFDL-CM4C192, GFDL-AM4, EC-Earth3-Veg-LR, EC-Earth3-Veg, UKESM1-0-LL, MRI-ESM2-0, GFDL-ESM4, CAMS-CSM1-0, GISS-E2-2-G, KIOS...</td>\n",
-       "      <td>{ta700, prveg, utendogw, thetaoga, msftbarot, siarean, fddtdin, wetso2, fbddtdife, rlutaf, epsi100, utendvtem, zo2min, eparag100, tnt, drynh4, zos, od550ss, phyfeos, treeFracBdlEvg, msftyzsmpa, cl...</td>\n",
+       "      <td>{GFDL-CM4, IPSL-CM6A-LR, MRI-AGCM3-2-H, HadGEM3-GC31-MM, IPSL-CM6A-LR-INCA, ICON-ESM-LR, CMCC-CM2-SR5, CAS-ESM2-0, MPI-ESM1-2-HR, IPSL-CM6A-ATM-HR, CanESM5, INM-CM5-0, GFDL-AM4, HadGEM3-GC31-HM, C...</td>\n",
+       "      <td>{msftyrho, dissoc, siltfrac, expc, pathetao, sndmasssnf, intpbp, tasmin, wap500, dispkexyfo, physi, cProductLut, bddtdife, sfno2, chldiat, cheaqpso4, mrsosLut, dryso2, wetso2, burntFractionAll, al...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>google_cmip6</th>\n",
-       "      <td>{MRI-AGCM3-2-H, CIESM, CanESM5, FGOALS-f3-L, HadGEM3-GC31-MM, INM-CM5-0, GFDL-CM4C192, GFDL-AM4, EC-Earth3-Veg-LR, EC-Earth3-Veg, UKESM1-0-LL, MRI-ESM2-0, GFDL-ESM4, CAMS-CSM1-0, GISS-E2-2-G, KIOS...</td>\n",
-       "      <td>{ta700, prveg, utendogw, thetaoga, msftbarot, siarean, fddtdin, wetso2, fbddtdife, rlutaf, epsi100, utendvtem, zo2min, eparag100, tnt, drynh4, zos, od550ss, phyfeos, treeFracBdlEvg, msftyzsmpa, cl...</td>\n",
+       "      <td>{GFDL-CM4, IPSL-CM6A-LR, MRI-AGCM3-2-H, HadGEM3-GC31-MM, IPSL-CM6A-LR-INCA, ICON-ESM-LR, CMCC-CM2-SR5, CAS-ESM2-0, MPI-ESM1-2-HR, IPSL-CM6A-ATM-HR, CanESM5, INM-CM5-0, GFDL-AM4, HadGEM3-GC31-HM, C...</td>\n",
+       "      <td>{msftyrho, dissoc, siltfrac, expc, pathetao, sndmasssnf, wap500, tasmin, intpbp, dispkexyfo, physi, cProductLut, bddtdife, sfno2, chldiat, cheaqpso4, mrsosLut, dryso2, wetso2, burntFractionAll, al...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -655,7 +655,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 3 subcatalog(s) across 177 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 3 source(s) across 177 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -686,17 +686,17 @@
        "    <tr>\n",
        "      <th>aws_cesm2_lens</th>\n",
        "      <td>{CESM2-LENS}</td>\n",
-       "      <td>{DIC, U, aice_d, NPP, QRUNOFF, hi, SALT, FSNTOA, TREFMXAV, RAIN, Q, TREFHT, WTT, PS, Z3, FLNSC, FLNS, PRECSC, O2, DOC, VVEL, PRECC, FSNO, PSL, nan, TREFHTMX, SHFLX, SOILLIQ, FLUT, PRECSL, T, VNT, ...</td>\n",
+       "      <td>{SOILWATER_10CM, TMQ, O2, V, WVEL, SNOW, DIC, Q, FLNS, FLNSC, hi, UVEL, T, Z3, RAIN, H2OSNO, ICEFRAC, PSL, PRECSL, NPP, nan, QRUNOFF, TREFHTMN, U, SALT, TEMP, FLUT, WTS, LHFLX, FSNSC, TREFHT, aice...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>aws_cmip6</th>\n",
-       "      <td>{MRI-AGCM3-2-H, CIESM, CanESM5, FGOALS-f3-L, HadGEM3-GC31-MM, INM-CM5-0, GFDL-CM4C192, GFDL-AM4, EC-Earth3-Veg-LR, EC-Earth3-Veg, UKESM1-0-LL, MRI-ESM2-0, GFDL-ESM4, CAMS-CSM1-0, GISS-E2-2-G, KIOS...</td>\n",
-       "      <td>{ta700, prveg, utendogw, thetaoga, msftbarot, siarean, fddtdin, wetso2, fbddtdife, rlutaf, epsi100, utendvtem, zo2min, eparag100, tnt, drynh4, zos, od550ss, phyfeos, treeFracBdlEvg, msftyzsmpa, cl...</td>\n",
+       "      <td>{GFDL-CM4, IPSL-CM6A-LR, MRI-AGCM3-2-H, HadGEM3-GC31-MM, IPSL-CM6A-LR-INCA, ICON-ESM-LR, CMCC-CM2-SR5, CAS-ESM2-0, MPI-ESM1-2-HR, IPSL-CM6A-ATM-HR, CanESM5, INM-CM5-0, GFDL-AM4, HadGEM3-GC31-HM, C...</td>\n",
+       "      <td>{msftyrho, dissoc, siltfrac, expc, pathetao, sndmasssnf, intpbp, tasmin, wap500, dispkexyfo, physi, cProductLut, bddtdife, sfno2, chldiat, cheaqpso4, mrsosLut, dryso2, wetso2, burntFractionAll, al...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>google_cmip6</th>\n",
-       "      <td>{MRI-AGCM3-2-H, CIESM, CanESM5, FGOALS-f3-L, HadGEM3-GC31-MM, INM-CM5-0, GFDL-CM4C192, GFDL-AM4, EC-Earth3-Veg-LR, EC-Earth3-Veg, UKESM1-0-LL, MRI-ESM2-0, GFDL-ESM4, CAMS-CSM1-0, GISS-E2-2-G, KIOS...</td>\n",
-       "      <td>{ta700, prveg, utendogw, thetaoga, msftbarot, siarean, fddtdin, wetso2, fbddtdife, rlutaf, epsi100, utendvtem, zo2min, eparag100, tnt, drynh4, zos, od550ss, phyfeos, treeFracBdlEvg, msftyzsmpa, cl...</td>\n",
+       "      <td>{GFDL-CM4, IPSL-CM6A-LR, MRI-AGCM3-2-H, HadGEM3-GC31-MM, IPSL-CM6A-LR-INCA, ICON-ESM-LR, CMCC-CM2-SR5, CAS-ESM2-0, MPI-ESM1-2-HR, IPSL-CM6A-ATM-HR, CanESM5, INM-CM5-0, GFDL-AM4, HadGEM3-GC31-HM, C...</td>\n",
+       "      <td>{msftyrho, dissoc, siltfrac, expc, pathetao, sndmasssnf, wap500, tasmin, intpbp, dispkexyfo, physi, cProductLut, bddtdife, sfno2, chldiat, cheaqpso4, mrsosLut, dryso2, wetso2, burntFractionAll, al...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -801,7 +801,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 2 subcatalog(s) across 2 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 2 source(s) across 2 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -832,12 +832,12 @@
        "    <tr>\n",
        "      <th>aws_cmip6</th>\n",
        "      <td>{CanESM5}</td>\n",
-       "      <td>{prveg, msftbarot, utendogw, epfz, fgo2, utendvtem, zo2min, difvso, gpp, pon, zos, spco2, clwvi, msftmz, epfy, sftof, tasmin, prra, mrros, tos, utendepfd, opottemppmdiff, utendwtem, hur, tauvo, ph...</td>\n",
+       "      <td>{prveg, osaltdiff, tasmin, tsl, phyc, cLeaf, co3, tosga, prsn, lai, uas, agessc, ua, osaltpmdiff, co3satcalc, areacella, tauvo, vtem, sfcWind, hursmin, dpco2, hfbasin, detoc, psl, spco2, siu, spco...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>google_cmip6</th>\n",
        "      <td>{CanESM5}</td>\n",
-       "      <td>{prveg, utendogw, msftbarot, epfz, fgo2, utendvtem, zo2min, difvso, gpp, pon, zos, spco2, clwvi, msftmz, epfy, sftof, tasmin, prra, utendepfd, tos, mrros, opottemppmdiff, utendwtem, hur, phyn, tau...</td>\n",
+       "      <td>{prveg, osaltdiff, tasmin, tsl, phyc, cLeaf, co3, tosga, prsn, lai, uas, agessc, ua, osaltpmdiff, co3satcalc, areacella, tauvo, sfcWind, vtem, hursmin, dpco2, hfbasin, detoc, psl, spco2, siu, spco...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -878,7 +878,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 2 subcatalog(s) across 2 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 2 source(s) across 2 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -909,7 +909,7 @@
        "    <tr>\n",
        "      <th>aws_cmip6</th>\n",
        "      <td>{CanESM5}</td>\n",
-       "      <td>{msftmzmpa, thetao}</td>\n",
+       "      <td>{thetao, msftmzmpa}</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>google_cmip6</th>\n",
@@ -955,7 +955,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 1 subcatalog(s) across 1 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 1 source(s) across 1 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -986,7 +986,7 @@
        "    <tr>\n",
        "      <th>aws_cmip6</th>\n",
        "      <td>{CanESM5}</td>\n",
-       "      <td>{msftmzmpa, thetao}</td>\n",
+       "      <td>{thetao, msftmzmpa}</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1027,7 +1027,7 @@
     {
      "data": {
       "text/html": [
-       "<p><strong>Intake dataframe catalog with 2 subcatalog(s) across 2 rows</strong>:</p> <div>\n",
+       "<p><strong>Intake dataframe catalog with 2 source(s) across 2 rows</strong>:</p> <div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -1288,7 +1288,7 @@
    "id": "668d133b-e8fb-41ca-80cf-db49627d4c43",
    "metadata": {},
    "source": [
-    "Alternatively, there are `.get_source` and `.get_sources_dict` methods. The former only works when there is only one source remaining in the dataframe catalog (e.g. after performing `.search` operations). The latter loads all sources into a dictionary with the corresponding source names as keys:"
+    "Alternatively, there are `.to_source` and `.to_source_dict` methods. The former only works when there is only one source remaining in the dataframe catalog (e.g. after performing `.search` operations). The latter loads all sources into a dictionary with the corresponding source names as keys:"
    ]
   },
   {
@@ -1376,9 +1376,9 @@
     }
    ],
    "source": [
-    "subcat = cat.search(variable=\"TEMP\").get_source()\n",
+    "source = cat.search(variable=\"TEMP\").to_source()\n",
     "\n",
-    "subcat"
+    "source"
    ]
   },
   {
@@ -1391,8 +1391,8 @@
      "data": {
       "text/plain": [
        "{'aws_cesm2_lens': <aws-cesm2-le catalog with 40 dataset(s) from 322 asset(s)>,\n",
-       " 'google_cmip6': <pangeo-cmip6 catalog with 7674 dataset(s) from 514818 asset(s)>,\n",
-       " 'aws_cmip6': <pangeo-cmip6 catalog with 7780 dataset(s) from 522217 asset(s)>}"
+       " 'aws_cmip6': <pangeo-cmip6 catalog with 7780 dataset(s) from 522217 asset(s)>,\n",
+       " 'google_cmip6': <pangeo-cmip6 catalog with 7674 dataset(s) from 514818 asset(s)>}"
       ]
      },
      "execution_count": 23,
@@ -1401,9 +1401,9 @@
     }
    ],
    "source": [
-    "subcat_dict = cat.get_source_dict()\n",
+    "source_dict = cat.to_source_dict()\n",
     "\n",
-    "subcat_dict"
+    "source_dict"
    ]
   },
   {
@@ -1411,7 +1411,7 @@
    "id": "ab8024ab-e02d-4c6c-aea6-5eaefa5750c8",
    "metadata": {},
    "source": [
-    "Once sources are loaded, we can access data in the normal way for that intake source type. For example, see the [intake-esm documentation](https://intake-esm.readthedocs.io/en/latest/index.html) for how to use intake-esm catalogs like the ones we've using in this demonstration."
+    "Once sources are loaded, we can access data in the normal way for that intake source type. For example, see the [intake-esm documentation](https://intake-esm.readthedocs.io/en/latest/index.html) for how to use intake-esm datastores like the ones we've been using in this demonstration."
    ]
   }
  ],

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -3,7 +3,7 @@
 API reference
 =============
 
-Excluding some supporting functions, intake_dataframe_catalog comprises a just single class, :code:`intake_dataframe_catalog.core.DfFileCatalog`, for loading/creating/managing a table of intake (sub)catalogs. This class is registered as an `intake driver <https://intake.readthedocs.io/en/latest/making-plugins.html#making-drivers>`_ called :code:`df_catalog`, meaning that intake will automatically create an :code:`open_df_catalog` convenience function under the intake module namespace. Calling :code:`intake.open_df_catalog()` is equivalent to instantiating the :code:`DfFileCatalog` class.
+Excluding some supporting functions, intake_dataframe_catalog comprises a just single class, :code:`intake_dataframe_catalog.core.DfFileCatalog`, for loading/creating/managing a table of intake sources. This class is registered as an `intake driver <https://intake.readthedocs.io/en/latest/making-plugins.html#making-drivers>`_ called :code:`df_catalog`, meaning that intake will automatically create an :code:`open_df_catalog` convenience function under the intake module namespace. Calling :code:`intake.open_df_catalog()` is equivalent to instantiating the :code:`DfFileCatalog` class.
 
 The following API summary is auto-generated.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "intake_dataframe_catalog"
 authors = [
     { name = "ACCESS-NRI" },
 ]
-description = "An intake driver for a searchable table of intake catalogs and associated metadata"
+description = "An intake driver for a searchable table of intake sources and associated metadata"
 readme = "README.rst"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -5,6 +5,7 @@ import ast
 import typing
 import warnings
 from io import UnsupportedOperation
+from warnings import warn
 
 import fsspec
 import intake
@@ -488,6 +489,60 @@ class DfFileCatalog(Catalog):
                 f"Expected exactly one source, received {len(self)}. Please refine your search or use "
                 "`.to_source_dict()`."
             )
+
+    def to_subcatalog_dict(
+        self, **kwargs: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        """
+        Load dataframe catalog entries into a dictionary of intake sources. NOTE, THIS METHOD WILL BE DEPRECIATED
+        IN THE NEXT RELEASE, PLEASE USE `to_source_dict` instead.
+
+        Parameters
+        ----------
+        kwargs: dict
+            Arguments/user parameters to use for opening the sources. For example, many intake drivers support
+            a `storage_options` argument with parameters to be passed to the backend file-system. Note, this function
+            passes the same kwargs to all sources in the dataframe catalog. To pass different kwargs to different
+            sources, load each source using it's key (name), e.g. `cat["<source_name>"](**kwargs)`.
+
+        Returns
+        -------
+        sources: dict
+            A dictionary of intake sources.
+        """
+
+        warn(
+            "This method will be depreciated in the next release. Please using `to_source_dict` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.to_source_dict(**kwargs)
+
+    def to_subcatalog(self, **kwargs: dict[str, typing.Any]) -> intake.DataSource:
+        """
+        Load intake source. This is only possible if there is only one remaining source in the dataframe
+        catalog. NOTE, THIS METHOD WILL BE DEPRECIATED IN THE NEXT RELEASE, PLEASE USE `to_source` instead.
+
+        Parameters
+        ----------
+        kwargs: dict
+            Arguments/user parameters to use for opening the intake source. For example, many intake drivers support
+            a `storage_options` argument with parameters to be passed to the backend file-system.`.
+
+        Returns
+        -------
+        source: :py:class:`intake.DataSource`
+            A dictionary of sources.
+        """
+
+        warn(
+            "This method will be depreciated in the next release. Please using `to_source` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.to_source(**kwargs)
 
     @property
     def df(self) -> pd.DataFrame:

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -27,13 +27,13 @@ class DfFileCatalogError(Exception):
 
 class DfFileCatalog(Catalog):
     """
-    A table of intake (sub)catalogs and associated metadata.
+    A table of intake sources and associated metadata.
     """
 
     version = __version__
     container = "catalog"
     partition_access = None
-    name = "dataframe_file_cat"
+    name = "dataframe_catalog"
 
     def __init__(
         self,
@@ -55,9 +55,9 @@ class DfFileCatalog(Catalog):
             Path to the dataframe catalog file.
         yaml_column: str, optional
             Name of the column in the dataframe catalog file containing intake yaml descriptions of the
-            intake (sub)catalogs.
+            intake sources.
         name_column: str, optional
-            Name of the column in the dataframe catalog file containing the names of the intake (sub)catalogs.
+            Name of the column in the dataframe catalog file containing the names of the intake sources.
         mode: str, optional
             The access mode. Options are:
             - `r` for read-only; no data can be modified.
@@ -127,13 +127,13 @@ class DfFileCatalog(Catalog):
                 if self.yaml_column not in self.df.columns:
                     raise DfFileCatalogError(
                         f"'{self.yaml_column}' is not a column in the dataframe catalog. Please provide "
-                        "the name of the column containing intake YAML descriptions via argument "
-                        "`yaml_column`."
+                        "the name of the column containing the intake source YAML descriptions via "
+                        "argument `yaml_column`."
                     )
                 if self.name_column not in self.df.columns:
                     raise DfFileCatalogError(
                         f"'{self.name_column}' is not a column in the dataframe catalog. Please provide "
-                        "the name of the column containing subcatalog names via argument "
+                        "the name of the column containing the intake source names via argument "
                         "`name_column`."
                     )
 
@@ -168,12 +168,12 @@ class DfFileCatalog(Catalog):
                 ).get()
                 return self._entries[key]
             raise KeyError(
-                f"key='{key}' not found in catalog. You can access the list of valid keys via the .keys() method."
+                f"key='{key}' not found in catalog. You can access the list of valid source keys via the .keys() method."
             ) from e
 
     def __repr__(self) -> str:
         return (
-            f"<{self.name or 'Intake dataframe'} catalog with {len(self)} subcatalog(s) across "
+            f"<{self.name or 'Intake dataframe'} catalog with {len(self)} source(s) across "
             f"{len(self.df)} rows>"
         )
 
@@ -185,7 +185,7 @@ class DfFileCatalog(Catalog):
         text = self.df_summary._repr_html_()
 
         return (
-            f"<p><strong>{self.name or 'Intake dataframe'} catalog with {len(self)} subcatalog(s) across "
+            f"<p><strong>{self.name or 'Intake dataframe'} catalog with {len(self)} source(s) across "
             f"{len(self.df)} rows</strong>:</p> {text}"
         )
 
@@ -200,7 +200,7 @@ class DfFileCatalog(Catalog):
 
     def keys(self) -> list[str]:
         """
-        Return a list of keys for the dataframe catalog entries (subcatalogs).
+        Return a list of keys for the dataframe catalog entries (sources).
         """
         return self.unique()[self.name_column]
 
@@ -212,7 +212,7 @@ class DfFileCatalog(Catalog):
         Returns
         -------
         entries: dict
-            Dictionary of all available entries (subcatalogs) in the dataframe catalog.
+            Dictionary of all available entries (sources) in the dataframe catalog.
         """
 
         missing = set(self.keys()) - set(self._entries.keys())
@@ -246,42 +246,42 @@ class DfFileCatalog(Catalog):
 
     def add(
         self,
-        cat: intake.DataSource,
+        source: intake.DataSource,
         metadata: dict[str, typing.Any] = None,
         overwrite: bool = False,
     ) -> None:
         """
-        Add an intake (sub)catalog to the dataframe catalog.
+        Add an intake source to the dataframe catalog.
 
         Parameters
         ----------
-        cat: object
-            An intake catalog object with a .yaml() method.
+        source: object
+            An intake source object with a .yaml() method.
         metadata: dict, optional
-            Dictionary of metadata associated with the intake (sub)catalog. If an entry is provided
-            corresponding to the 'name_column', the catalog name will be overwritten with this value.
-            Otherwise the corresponding 'name_column' entry is taken from the intake catalog name if
+            Dictionary of metadata associated with the intake source. If an entry is provided
+            corresponding to the 'name_column', the source name will be overwritten with this value.
+            Otherwise the corresponding 'name_column' entry is taken from the intake source name if
             it exists, failing otherwise.
         overwrite: bool, optional
             If True, overwrite all existing entries in the dataframe catalog with name_column entries
-            that match the name of this cat. Otherwise the entry is appended to the dataframe catalog.
+            that match the name of this source. Otherwise the entry is appended to the dataframe catalog.
         """
 
         metadata = metadata or {}
         metadata_keys = list(metadata.keys())
 
         if self.name_column in metadata:
-            cat.name = metadata[self.name_column]
+            source.name = metadata[self.name_column]
         else:
-            if cat.name:
-                metadata[self.name_column] = cat.name
+            if source.name:
+                metadata[self.name_column] = source.name
             else:
                 raise DfFileCatalogError(
-                    "Cannot add an unnamed catalog to the dataframe catalog. Either set the name attribute "
-                    "on the catalog being add or provide an entry in the input argument 'metadata' "
+                    "Cannot add an unnamed source to the dataframe catalog. Either set the name attribute "
+                    "on the source being add or provide an entry in the input argument 'metadata' "
                     "corresponding to the 'name_column' of the dataframe catalog."
                 )
-        metadata[self.yaml_column] = cat.yaml()
+        metadata[self.yaml_column] = source.yaml()
 
         row = pd.DataFrame({k: 0 for k in metadata.keys()}, index=[0])
         row.iloc[0] = pd.Series(metadata)
@@ -319,12 +319,12 @@ class DfFileCatalog(Catalog):
 
     def remove(self, entry: str) -> None:
         """
-        Remove an intake (sub)catalog from the dataframe catalog.
+        Remove an intake source from the dataframe catalog.
 
         Parameters
         ----------
         entry: str
-            The corresponding 'name_column' entry for the (sub)catalog to remove.
+            The corresponding 'name_column' entry for the source to remove.
         """
 
         if entry in self.df[self.name_column].unique():
@@ -346,11 +346,11 @@ class DfFileCatalog(Catalog):
 
     def search(self, require_all: bool = False, **query: typing.Any) -> "DfFileCatalog":
         """
-        Search for subcatalogs in the dataframe catalog. Multiple columns can be queried simultaneously
-        by passing multiple queries. Only subcatalogs that satisfy all column queries are returned.
+        Search for sources in the dataframe catalog. Multiple columns can be queried simultaneously
+        by passing multiple queries. Only sources that satisfy all column queries are returned.
         Additionally, multiple values within a column can be queried by passing a list of values to
         query on. By default, a column query is considered to match if any of the values are found
-        in the corresponding subcatalog metadata (see the `require_all` argument).
+        in the corresponding source metadata (see the `require_all` argument).
 
         Parameters
         ----------
@@ -358,8 +358,8 @@ class DfFileCatalog(Catalog):
             A dictionary of query parameters to execute against the dataframe catalog of the form
             {column_name: value[s]}.
         require_all : bool, optional
-            If True, returned subcatalogs satisfy all the query criteria. For example, a query of
-            `variable = ["a", "b"]` with `require_all = True` will return only subcatalogs that
+            If True, returned sources satisfy all the query criteria. For example, a query of
+            `variable = ["a", "b"]` with `require_all = True` will return only sources that
             contain _both_ variables "a" and "b".
 
         Returns
@@ -435,60 +435,58 @@ class DfFileCatalog(Catalog):
 
     serialize = save
 
-    def to_subcatalog_dict(
-        self, **kwargs: dict[str, typing.Any]
-    ) -> dict[str, typing.Any]:
+    def to_source_dict(self, **kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
         """
-        Load dataframe catalog entries into a dictionary of intake subcatalogs.
+        Load dataframe catalog entries into a dictionary of intake sources.
 
         Parameters
         ----------
         kwargs: dict
-            Arguments/user parameters to use for opening the subcatalog(s). For example, many intake drivers support
+            Arguments/user parameters to use for opening the sources. For example, many intake drivers support
             a `storage_options` argument with parameters to be passed to the backend file-system. Note, this function
-            passes the same kwargs to all subcatalogs in the DF catalog. To pass different kwargs to different
-            subcatalogs, load each subcatalog using it's key (name), e.g. `cat["<subcat_name>"](**kwargs)`.
+            passes the same kwargs to all sources in the dataframe catalog. To pass different kwargs to different
+            sources, load each source using it's key (name), e.g. `cat["<source_name>"](**kwargs)`.
 
         Returns
         -------
-        subcatalogs: dict
-            A dictionary of subcatalogs.
+        sources: dict
+            A dictionary of intake sources.
         """
 
         if not self.keys():
             warnings.warn(
-                "There are no subcatalogs to open. Returning an empty dictionary.",
+                "There are no sources to open. Returning an empty dictionary.",
                 UserWarning,
                 stacklevel=2,
             )
 
-        return {key: subcat(**kwargs) for key, subcat in self.items()}
+        return {key: source(**kwargs) for key, source in self.items()}
 
-    def to_subcatalog(self, **kwargs: dict[str, typing.Any]) -> intake.DataSource:
+    def to_source(self, **kwargs: dict[str, typing.Any]) -> intake.DataSource:
         """
-        Load intake subcatalog. This is only possible if there is only one remaining subcatalog in the dataframe
+        Load intake source. This is only possible if there is only one remaining source in the dataframe
         catalog.
 
         Parameters
         ----------
         kwargs: dict
-            Arguments/user parameters to use for opening the subcatalog. For example, many intake drivers support
+            Arguments/user parameters to use for opening the intake source. For example, many intake drivers support
             a `storage_options` argument with parameters to be passed to the backend file-system.`.
 
         Returns
         -------
-        subcatalog: :py:class:`intake.DataSource`
-            A dictionary of subcatalogs.
+        source: :py:class:`intake.DataSource`
+            A dictionary of sources.
         """
 
         if len(self) == 1:
-            res = self.to_subcatalog_dict(**kwargs)
-            _, subcat = res.popitem()
-            return subcat
+            res = self.to_source_dict(**kwargs)
+            _, source = res.popitem()
+            return source
         else:
             raise ValueError(
-                f"Expected exactly one subcatalog, received {len(self)}. Please refine your search or use "
-                "`.to_subcatalog_dict()`."
+                f"Expected exactly one source, received {len(self)}. Please refine your search or use "
+                "`.to_source_dict()`."
             )
 
     @property

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -682,6 +682,27 @@ def test_subclassing_catalog(catalog_path):
     assert type(scat) is ChildCatalog
 
 
+def test_to_subcatalog_depreciated(catalog_path):
+    cat = intake.open_df_catalog(
+        path=str(catalog_path / "dfcat.csv"),
+        columns_with_iterables=["variable"],
+        mode="a",
+    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="This method will be depreciated in the next release",
+    ):
+        cat.to_subcatalog_dict()
+
+    cat_new = cat.search(name="cesm")
+    with pytest.warns(
+        DeprecationWarning,
+        match="This method will be depreciated in the next release",
+    ):
+        cat_new.to_subcatalog()
+
+
 def _assert_DfFileCatalog(cat, empty=False):
     """
     Assert that the input is a DfFileCatalog

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -105,8 +105,9 @@ def test_column_name_error(catalog_path):
             name_column="bar",
             mode="r",
         )
-    assert "Please provide the name of the column containing subcatalog names" in str(
-        excinfo.value
+    assert (
+        "Please provide the name of the column containing the intake source names"
+        in str(excinfo.value)
     )
 
 
@@ -226,7 +227,7 @@ def test_catalog_unique(catalog_path, query, expected_unique, expected_nunique):
 
 def test_catalog_contains(catalog_path):
     """
-    Test subcat in cat operations
+    Test source in cat operations
     """
     cat = intake.open_df_catalog(
         str(catalog_path / "dfcat.csv"),
@@ -304,7 +305,7 @@ def test_bad_search(catalog_path):
 
 def test_catalog_add(catalog_path, source_path):
     """
-    Test adding subcatalogs to the catalog
+    Test adding sources to the catalog
     """
     cat = intake.open_df_catalog(str(catalog_path / "tmp.csv"), mode="w")
 
@@ -341,7 +342,7 @@ def test_catalog_add(catalog_path, source_path):
 
 def test_catalog_remove(catalog_path):
     """
-    Test removing subcatalogs from the catalog
+    Test removing sources from the catalog
     """
     cat = intake.open_df_catalog(
         str(catalog_path / "dfcat.csv"),
@@ -357,7 +358,7 @@ def test_catalog_remove(catalog_path):
 
 def test_catalog_add_remove(catalog_path, source_path):
     """
-    Test adding and removing subcatalogs to the catalog
+    Test adding and removing sources to the catalog
     """
     cat = intake.open_df_catalog(str(catalog_path / "tmp.csv"), mode="w")
 
@@ -398,10 +399,10 @@ def test_use_metadata_name(catalog_path, source_path):
         str(catalog_path / "tmp.csv"),
         mode="w",
     )
-    subcat = intake.open_csv(str(source_path / "gistemp.csv"))
-    subcat.name = "gistemp"
+    source = intake.open_csv(str(source_path / "gistemp.csv"))
+    source.name = "gistemp"
 
-    cat.add(subcat, metadata={"name": "new_name"})
+    cat.add(source, metadata={"name": "new_name"})
     assert "new_name" in cat
     assert "gistemp" not in cat
 
@@ -417,7 +418,7 @@ def test_use_metadata_name(catalog_path, source_path):
 )
 def test_catalog_getitem(catalog_path, key, expected):
     """
-    Test getting subcatalogs from catalog
+    Test getting sources from catalog
     """
     cat = intake.open_df_catalog(
         str(catalog_path / "dfcat.csv"),
@@ -501,9 +502,9 @@ def test_catalog_save(catalog_path, method, kwargs):
         {},
     ],
 )
-def test_to_subcatalog(catalog_path, kwargs):
+def test_to_source(catalog_path, kwargs):
     """
-    Test to_subcatalog and to_subcatalog_dict methods
+    Test to_source and to_source_dict methods
     """
     cat = intake.open_df_catalog(
         path=str(catalog_path / "dfcat.csv"),
@@ -512,32 +513,32 @@ def test_to_subcatalog(catalog_path, kwargs):
     )
 
     with pytest.raises(ValueError) as excinfo:
-        cat.to_subcatalog(**kwargs)
-    assert "Expected exactly one subcatalog" in str(excinfo.value)
+        cat.to_source(**kwargs)
+    assert "Expected exactly one source" in str(excinfo.value)
 
-    cat.to_subcatalog_dict(**kwargs)
+    cat.to_source_dict(**kwargs)
 
     cat_new = cat.search(name="cesm")
-    cat_new.to_subcatalog(**kwargs)
+    cat_new.to_source(**kwargs)
 
 
 def test_empty_catalog(catalog_path):
     """
-    Test warning when trying to load subcatalog from empty catalog
+    Test warning when trying to load source from empty catalog
     """
     cat = intake.open_df_catalog(path=str(catalog_path / "tmp.csv"), mode="w")
 
     with pytest.warns(
         UserWarning,
-        match=r"There are no subcatalogs to open. Returning an empty dictionary.",
+        match=r"There are no sources to open. Returning an empty dictionary.",
     ):
-        subcats = cat.to_subcatalog_dict()
-        assert not subcats
+        sources = cat.to_source_dict()
+        assert not sources
 
 
-def test_read_subcatalog(catalog_path):
+def test_read_source(catalog_path):
     """
-    Test reading data from subcatalogs
+    Test reading data from sources
     """
     from distributed import Client
 
@@ -627,10 +628,10 @@ def test_df_summary(catalog_path, source_path, metadata, expected_dict):
         str(catalog_path / "tmp.csv"),
         mode="w",
     )
-    subcat = intake.open_csv(str(source_path / "gistemp.csv"))
+    source = intake.open_csv(str(source_path / "gistemp.csv"))
 
     for meta in metadata:
-        cat.add(subcat, metadata=meta)
+        cat.add(source, metadata=meta)
 
     assert cat.df_summary.to_dict(orient="split", index=False) == expected_dict
 
@@ -643,21 +644,21 @@ def test_df_summary_update(catalog_path, source_path):
         str(catalog_path / "tmp.csv"),
         mode="w",
     )
-    subcat = intake.open_csv(str(source_path / "gistemp.csv"))
-    subcat.name = "gistemp"
+    source = intake.open_csv(str(source_path / "gistemp.csv"))
+    source.name = "gistemp"
 
     expected_dict = {"columns": [], "data": []}
     assert cat.df_summary.to_dict(orient="split", index=False) == expected_dict
 
-    cat.add(subcat, metadata={"meta0": "a", "meta1": "b"})
+    cat.add(source, metadata={"meta0": "a", "meta1": "b"})
     expected_dict = {"columns": ["meta0", "meta1"], "data": [[{"a"}, {"b"}]]}
     assert cat.df_summary.to_dict(orient="split", index=False) == expected_dict
 
-    cat.add(subcat, metadata={"meta0": "c", "meta1": "d"})
+    cat.add(source, metadata={"meta0": "c", "meta1": "d"})
     expected_dict = {"columns": ["meta0", "meta1"], "data": [[{"a", "c"}, {"b", "d"}]]}
     assert cat.df_summary.to_dict(orient="split", index=False) == expected_dict
 
-    cat.add(subcat, metadata={"meta0": "c", "meta1": "d"}, overwrite=True)
+    cat.add(source, metadata={"meta0": "c", "meta1": "d"}, overwrite=True)
     expected_dict = {"columns": ["meta0", "meta1"], "data": [[{"c"}, {"d"}]]}
     assert cat.df_summary.to_dict(orient="split", index=False) == expected_dict
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,7 @@ def test_column_name_error(catalog_path):
             mode="r",
         )
     assert (
-        "Please provide the name of the column containing intake YAML descriptions"
+        "Please provide the name of the column containing the intake source YAML descriptions"
         in str(excinfo.value)
     )
 
@@ -314,9 +314,7 @@ def test_catalog_add(catalog_path, source_path):
 
     with pytest.raises(DfFileCatalogError) as excinfo:
         cat.add(gistemp, metadata={"realm": "atmos", "variable": ["tas"]})
-    assert "Cannot add an unnamed catalog to the dataframe catalog" in str(
-        excinfo.value
-    )
+    assert "Cannot add an unnamed source to the dataframe catalog" in str(excinfo.value)
 
     gistemp.name = "gistemp"
     cat.add(gistemp, metadata={"realm": "atmos", "variable": ["tas"]})


### PR DESCRIPTION
In intake terminology, intake-dataframe-catalog is really a table of intake sources. Calling the sources subcatalogs came from the original use case where the entries are intake-esm datastores (often called catalogs), but this is confusing.

Here we change all references to entries as intake sources

Closes #27 