### PR TITLE
Fix catalog scrolling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+0.2.2
+-----
+
+Released 19/05/2023
+
+- Fix broken scrolling of :code:`_ipython_display_` in some JupyterLabs (:issue:`41`, :pull:`42`). 
+  By `Dougie Squire <https://github.com/dougiesquire>`_.
+
 0.2.1
 -----
 

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -183,7 +183,7 @@ class DfFileCatalog(Catalog):
         Return an html summary for the dataframe catalog object. Mainly for IPython notebook.
         """
 
-        text = f"<div style='max-height: 300px'>{self.df_summary._repr_html_()}</div>"
+        text = f"<div style='max-height: 300px; overflow: auto; width: fit-content'>{self.df_summary._repr_html_()}</div>"
 
         return (
             f"<p><strong>{self.name or 'Intake dataframe'} catalog with {len(self)} source(s) across "


### PR DESCRIPTION
Catalog html summary doesn't scroll in some JupyterLabs