### PR TITLE
Use yaml full_load to load entry yaml descriptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+0.2.3
+-----
+
+Not yet released
+
+- Use :code:`yaml.full_load` rather than :code:`yaml.safe_load` to load entry yaml descriptions
+  to allow for python-specific tags (:issue:`45`, :pull:`46`). By 
+  `Dougie Squire <https://github.com/dougiesquire>`_.
+
 0.2.2
 -----
 

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -2,7 +2,6 @@ name: intake-df-cat-test
 channels:
   - conda-forge
 dependencies:
-  - black
   - intake
   - intake-esm
   - pytest
@@ -10,7 +9,6 @@ dependencies:
   - pip
   - pip:
     - build
-    - ruff
     - codecov
     - pre-commit
     - pytest-cov

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -2,7 +2,6 @@ name: intake-df-cat-test
 channels:
   - conda-forge
 dependencies:
-  - black
   - intake
   - intake-esm
   - pytest
@@ -10,7 +9,6 @@ dependencies:
   - pip
   - pip:
     - build
-    - ruff
     - codecov
     - pre-commit
     - pytest-cov

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -2,7 +2,6 @@ name: intake-df-cat-test
 channels:
   - conda-forge
 dependencies:
-  - black
   - intake
   - intake-esm
   - pytest
@@ -10,7 +9,6 @@ dependencies:
   - pip
   - pip:
     - build
-    - ruff
     - codecov
     - pre-commit
     - pytest-cov

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -165,7 +165,7 @@ class DfFileCatalog(Catalog):
                     assert all(y == yaml_text for y in yamls)
 
                 self._entries[key] = LocalCatalogEntry(
-                    name=key, **yaml.safe_load(yaml_text)["sources"][key]
+                    name=key, **yaml.full_load(yaml_text)["sources"][key]
                 ).get()
                 return self._entries[key]
             raise KeyError(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -561,6 +561,24 @@ def test_read_source(catalog_path):
     assert len(x) == len(cat.cmip5)
 
 
+def test_tags_in_yaml(catalog_path, source_path):
+    """
+    Test loading from a yaml description that contains python-specific tags
+    """
+
+    cat = intake.open_df_catalog(
+        path=str(catalog_path / "tmp.csv"),
+        mode="w",
+    )
+
+    gistemp = intake.open_csv(str(source_path / "gistemp.csv"))
+    gistemp.name = "gistemp"
+    gistemp.metadata = {"tuple": (0, 1, 2), "complex": 1 + 1j}
+    cat.add(gistemp, metadata={"foo": "bar"})
+
+    cat["gistemp"]
+
+
 @pytest.mark.parametrize(
     "metadata, expected_dict",
     [


### PR DESCRIPTION
Currently, entry source yaml descriptions are loaded using `yaml.safe_load`. This fails when the yaml description contains python-specific tags and `safe_load `hasn't already been called (weirdly?...). This PR switches to using `yaml.full_load` which resolves all tags except those known to be unsafe.

Closes #45 