### PR TITLE
Fix for fsspec>=2023.10.0

### DIFF
--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -423,7 +423,7 @@ class DfFileCatalog(Catalog):
                 f"{save_path}", storage_options=self.storage_options
             )
             fs = mapper.fs
-            fname = f"{mapper.fs.protocol}://{save_path}"
+            fname = fs.unstrip_protocol(save_path)
 
             csv_kwargs = {"index": False}
             csv_kwargs.update(kwargs.copy() or {})


### PR DESCRIPTION
Instead of a custom f-string to get the full path of files, use a method of the filesystem object. This solves the string vs tuple issue.

Closes #49.