### PR TITLE
Added a _display module with a singleton to configure the display options.

### DIFF
--- a/src/intake_dataframe_catalog/_display.py
+++ b/src/intake_dataframe_catalog/_display.py
@@ -1,29 +1,29 @@
 from enum import Enum
 
+
 class _DisplayType(Enum):
     JUPYTER_NOTEBOOK = 0
     IPYTHON_REPL = 1
     REGULAR_REPL = 2
 
 
-
 class _DisplayOptions:
     """
     Singleton class to set display options for Pandas DataFrames.
     """
+
     _instance = None
 
-    def __new__(clf, *args, **kwargs):
-        if not clf._instance:
-            clf._instance = super(_DisplayOptions, clf).__new__(clf)
-        return clf._instance
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __init__(self):
-        if hasattr(self, 'initialized'):
+        if hasattr(self, "initialized"):
             return None
         self.set_pd_options()
         self.initialized = True
-
 
     def __str__(self):
         return f"DisplayOptions(display_type={self.display_type})"
@@ -39,9 +39,10 @@ class _DisplayOptions:
 
         if self.display_type == _DisplayType.JUPYTER_NOTEBOOK:
             import pandas as pd
-            pd.set_option('display.max_colwidth', 200)
-            pd.set_option('display.max_rows', None)
-        
+
+            pd.set_option("display.max_colwidth", 200)
+            pd.set_option("display.max_rows", None)
+
         return None
 
     @property
@@ -49,9 +50,9 @@ class _DisplayOptions:
         try:
             # Check for Jupyter Notebook
             ipy = get_ipython()
-            if hasattr(ipy, 'kernel'):
+            if hasattr(ipy, "kernel"):
                 return _DisplayType.JUPYTER_NOTEBOOK
-            elif hasattr(ipy, 'config'):
+            elif hasattr(ipy, "config"):
                 return _DisplayType.IPYTHON_REPL
         except NameError:
             return _DisplayType.REGULAR_REPL
@@ -59,5 +60,6 @@ class _DisplayOptions:
     @property
     def is_notebook(self) -> bool:
         return self.display_type == _DisplayType.JUPYTER_NOTEBOOK
+
 
 display_options = _DisplayOptions()

--- a/src/intake_dataframe_catalog/_display.py
+++ b/src/intake_dataframe_catalog/_display.py
@@ -1,0 +1,63 @@
+from enum import Enum
+
+class _DisplayType(Enum):
+    JUPYTER_NOTEBOOK = 0
+    IPYTHON_REPL = 1
+    REGULAR_REPL = 2
+
+
+
+class _DisplayOptions:
+    """
+    Singleton class to set display options for Pandas DataFrames.
+    """
+    _instance = None
+
+    def __new__(clf, *args, **kwargs):
+        if not clf._instance:
+            clf._instance = super(_DisplayOptions, clf).__new__(clf)
+        return clf._instance
+
+    def __init__(self):
+        if hasattr(self, 'initialized'):
+            return None
+        self.set_pd_options()
+        self.initialized = True
+
+
+    def __str__(self):
+        return f"DisplayOptions(display_type={self.display_type})"
+
+    def __repr__(self):
+        return str(self)
+
+    def set_pd_options(self) -> None:
+        """
+        Set display.max_colwidth to 200 and max_rows to None - but only if we are
+        in a Jupyter Notebook. Otherwise, leave the defaults.
+        """
+
+        if self.display_type == _DisplayType.JUPYTER_NOTEBOOK:
+            import pandas as pd
+            pd.set_option('display.max_colwidth', 200)
+            pd.set_option('display.max_rows', None)
+        
+        return None
+
+    @property
+    def display_type(self) -> _DisplayType:
+        try:
+            # Check for Jupyter Notebook
+            ipy = get_ipython()
+            if hasattr(ipy, 'kernel'):
+                return _DisplayType.JUPYTER_NOTEBOOK
+            elif hasattr(ipy, 'config'):
+                return _DisplayType.IPYTHON_REPL
+        except NameError:
+            return _DisplayType.REGULAR_REPL
+
+    @property
+    def is_notebook(self) -> bool:
+        return self.display_type == _DisplayType.JUPYTER_NOTEBOOK
+
+display_options = _DisplayOptions()

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -16,9 +16,7 @@ from intake.catalog.local import LocalCatalogEntry
 
 from . import __version__
 from ._search import search
-
-pd.set_option("display.max_colwidth", 200)
-pd.set_option("display.max_rows", None)
+from ._display import display_options as _display_opts
 
 
 class DfFileCatalogError(Exception):
@@ -194,10 +192,13 @@ class DfFileCatalog(Catalog):
         """
         Display the dataframe catalog object as a rich object in an IPython session.
         """
-        from IPython.display import HTML, display
+        if _display_opts.is_notebook:
+            from IPython.display import HTML, display
 
-        contents = self._repr_html_()
-        display(HTML(contents))
+            contents = self._repr_html_()
+            display(HTML(contents))
+        else:
+            print(self)
 
     def keys(self) -> list[str]:
         """

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -15,8 +15,8 @@ from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry
 
 from . import __version__
-from ._search import search
 from ._display import display_options as _display_opts
+from ._search import search
 
 
 class DfFileCatalogError(Exception):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,10 +1,11 @@
-from intake_dataframe_catalog._display import _DisplayOptions, _DisplayType
-import pytest
+from intake_dataframe_catalog._display import _DisplayOptions
+
 
 def test_display_opts_singleton():
     opts1 = _DisplayOptions()
     opts2 = _DisplayOptions()
     assert opts1 is opts2
+
 
 # Create a test that checks if get_ipython() has a kernel attribute, then the display_type should be JUPYTER_NOTEBOOK
 # If get_ipython() has a config attribute, then the display_type should be IPYTHON_REPL

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,11 @@
+from intake_dataframe_catalog._display import _DisplayOptions, _DisplayType
+import pytest
+
+def test_display_opts_singleton():
+    opts1 = _DisplayOptions()
+    opts2 = _DisplayOptions()
+    assert opts1 is opts2
+
+# Create a test that checks if get_ipython() has a kernel attribute, then the display_type should be JUPYTER_NOTEBOOK
+# If get_ipython() has a config attribute, then the display_type should be IPYTHON_REPL
+# If get_ipython() raises a NameError, then the display_type should be REGULAR_REPL


### PR DESCRIPTION
I've added a display config which uses a singleton to determine whether to optimise the catalogue display - when we're outside a notebook, interacting with the dataframe catalogue is generally a bit of a pain.

- I've used a singleton since the display options are necessarily bound to the kernel & live for the lifetime of the interpreter. This kind of makes testing a pain & introduces a lot of potentially unnecessary complexity, so we could either:
    - Use a private global
    - Change display_type from a property & initialise it at startup, and let the user alter it if they want.

With that said, the behaviour of `_DisplayOptions` is pretty simple & I'm not sure it even particularly needs thorough testing. 

Closes #64. 