### PR TITLE
Update meta.yaml & enable paths objects to be read

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -19,8 +19,8 @@ requirements:
     - pip
     - versioneer
   run:
-    - python >=3.9
-    - intake <2.0.0
+    - python >=3.10
+    - intake >=0.7.0
     - pandas
 
 test:

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -32,7 +32,6 @@ def _posixpath_constructor(
     return PosixPath(*value)
 
 
-# Add the constructor to SafeLoader
 yaml.SafeLoader.add_constructor(
     "tag:yaml.org,2002:python/object/apply:pathlib.PosixPath", _posixpath_constructor
 )

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -20,18 +20,22 @@ from ._display import display_options as _display_opts
 from ._search import search
 
 
-def _posixpath_constructor(loader : yaml.Loader, node : yaml.nodes.SequenceNode) -> PosixPath:
+def _posixpath_constructor(
+    loader: yaml.Loader, node: yaml.nodes.SequenceNode
+) -> PosixPath:
     """
     Allows us to represent a path within a yaml file as a path object, not just a string.
-    Necessitated by changes to access-nri-intake-catalog passing around path objects, not 
+    Necessitated by changes to access-nri-intake-catalog passing around path objects, not
     raw strings representing these paths.
     """
     value = loader.construct_sequence(node, deep=True)
     return PosixPath(*value)
 
-# Add the constructor to SafeLoader
-yaml.SafeLoader.add_constructor('tag:yaml.org,2002:python/object/apply:pathlib.PosixPath', _posixpath_constructor)
 
+# Add the constructor to SafeLoader
+yaml.SafeLoader.add_constructor(
+    "tag:yaml.org,2002:python/object/apply:pathlib.PosixPath", _posixpath_constructor
+)
 
 
 class DfFileCatalogError(Exception):

--- a/src/intake_dataframe_catalog/core.py
+++ b/src/intake_dataframe_catalog/core.py
@@ -5,6 +5,7 @@ import ast
 import typing
 import warnings
 from io import UnsupportedOperation
+from pathlib import PosixPath
 
 import fsspec
 import intake
@@ -17,6 +18,20 @@ from intake.catalog.local import LocalCatalogEntry
 from . import __version__
 from ._display import display_options as _display_opts
 from ._search import search
+
+
+def _posixpath_constructor(loader : yaml.Loader, node : yaml.nodes.SequenceNode) -> PosixPath:
+    """
+    Allows us to represent a path within a yaml file as a path object, not just a string.
+    Necessitated by changes to access-nri-intake-catalog passing around path objects, not 
+    raw strings representing these paths.
+    """
+    value = loader.construct_sequence(node, deep=True)
+    return PosixPath(*value)
+
+# Add the constructor to SafeLoader
+yaml.SafeLoader.add_constructor('tag:yaml.org,2002:python/object/apply:pathlib.PosixPath', _posixpath_constructor)
+
 
 
 class DfFileCatalogError(Exception):


### PR DESCRIPTION
__meta.yaml__
- Remove the intake < 2.0 requirement
- Bump minimum Python version to Python 3.10.

__core.py__
- Add a posixpath constructor allowing `PosixPath`s to be passed as a constructor to esm-datastores when loading them from the dataframe catalog using `yaml.safe_read()`- otherwise E2E tests fail in `access-nri-intake-catalog`. This appears to be something to do with paths being passed to builders. 
    - Still hunting down the change that necessitated this - appears to be post 1.0.0 release. 